### PR TITLE
Fix Deleted Donation Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,7 @@ var imraising = function imraising(options) {
             var data = JSON.parse(data);
 
             // ImRaising returns only the _id if a donation is deleted.
-            var amount = data.amount.display.total || 0.00;
-            if (amount === 0.00) { self.emit('donation.delete', data); }
+            if (!data.amount || !data.amount.display.total) { self.emit('donation.delete', data); }
             else { self.emit('donation.add', data); }
         });
     }


### PR DESCRIPTION
Because only _id is sent back in the case of a deleted donation, data.amount is undefined, which causes issues when trying to access the total. This PR fixes that issue.
